### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -31,6 +31,21 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/signup?email=student@mergington.edu` | Unregister from an activity                                         |
+
+## Running Tests
+
+Run backend tests with `pytest` from the repository root:
+
+```bash
+pytest -q tests
+```
+
+Run all discovered tests:
+
+```bash
+pytest -q
+```
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team-based soccer training, drills, and matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "ava@mergington.edu"]
+    },
+    "Swimming Club": {
+        "description": "Improve swimming techniques and endurance",
+        "schedule": "Tuesdays and Thursdays, 6:00 AM - 7:00 AM",
+        "max_participants": 18,
+        "participants": ["noah@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Workshop": {
+        "description": "Explore drawing, painting, and mixed media art",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["lucas@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Practice acting, stage performance, and improvisation",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["ethan@mergington.edu", "amelia@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Develop public speaking and critical thinking through debate",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 14,
+        "participants": ["james@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Compete in science challenges and collaborative problem-solving",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["henry@mergington.edu", "evelyn@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,28 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`Failed to load activities (${response.status})`);
+      }
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +33,30 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participants = details.participants || [];
+        const participantsMarkup =
+          participants.length > 0
+            ? `<ul class="participants-list">${participants
+                .map(
+                  (participant) =>
+                    `<li class="participant-item"><span class="participant-email">${participant}</span><button type="button" class="delete-participant" data-activity="${encodeURIComponent(
+                      name
+                    )}" data-email="${encodeURIComponent(
+                      participant
+                    )}" aria-label="Unregister ${participant}">🗑️</button></li>`
+                )
+                .join("")}</ul>`
+            : '<p class="participants-empty">No participants yet</p>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p><strong>Participants:</strong></p>
+            ${participantsMarkup}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -59,25 +91,52 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const target = event.target.closest(".delete-participant");
+    if (!target) {
+      return;
+    }
+
+    const activityName = decodeURIComponent(target.dataset.activity || "");
+    const participantEmail = decodeURIComponent(target.dataset.email || "");
+
+    if (!activityName || !participantEmail) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/signup?email=${encodeURIComponent(
+          participantEmail
+        )}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+        await fetchActivities();
+      } else {
+        showMessage(result.detail || "Unable to unregister participant", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to unregister participant. Please try again.", "error");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,66 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e3e8ef;
+}
+
+.participants-section p {
+  margin-bottom: 8px;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #ffffff;
+  border: 1px solid #e4e8ef;
+}
+
+.participant-email {
+  color: #34495e;
+  font-size: 14px;
+  word-break: break-word;
+}
+
+.delete-participant {
+  border: 1px solid #ef9a9a;
+  background-color: #fff5f5;
+  color: #c62828;
+  padding: 4px 7px;
+  border-radius: 6px;
+  cursor: pointer;
+  line-height: 1;
+  font-size: 14px;
+}
+
+.delete-participant:hover {
+  background-color: #ffebee;
+}
+
+.delete-participant:focus-visible {
+  outline: 2px solid #c62828;
+  outline-offset: 2px;
+}
+
+.participants-empty {
+  margin: 0;
+  font-style: italic;
+  color: #6c7a89;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,149 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_state = copy.deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(original_state)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    redirect_target = "/static/index.html"
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.headers["location"] == redirect_target
+
+
+def test_get_activities_returns_activity_dictionary(client):
+    # Arrange
+    expected_activity = "Chess Club"
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    payload = response.json()
+    assert expected_activity in payload
+    assert set(payload[expected_activity].keys()) == {
+        "description",
+        "schedule",
+        "max_participants",
+        "participants",
+    }
+
+
+def test_signup_adds_participant_to_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "newstudent@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert email in activities[activity_name]["participants"]
+    assert response.json()["message"] == f"Signed up {email} for {activity_name}"
+
+
+def test_signup_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Club"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": "student@mergington.edu"})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_duplicate_participant_returns_400(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": existing_email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_missing_email_returns_422(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup")
+
+    # Assert
+    assert response.status_code == 422
+
+
+def test_unregister_removes_participant_from_activity(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in activities[activity_name]["participants"]
+    assert response.json()["message"] == f"Unregistered {email} from {activity_name}"
+
+
+def test_unregister_unknown_activity_returns_404(client):
+    # Arrange
+    activity_name = "Unknown Club"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": "student@mergington.edu"})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_non_participant_returns_404(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "notenrolled@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"
+
+
+def test_unregister_missing_email_returns_422(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup")
+
+    # Assert
+    assert response.status_code == 422


### PR DESCRIPTION
This pull request adds the ability for students to unregister from activities, improves participant management in the frontend, and introduces comprehensive backend tests. It also expands the activity list and updates documentation to reflect these new features.

Backend features and API changes:

* Added a `DELETE /activities/{activity_name}/signup` endpoint to allow students to unregister from activities, including validation for unknown activities and non-participants.
* Expanded the initial activity dataset with several new clubs and workshops, each with their own details and participants.

Frontend improvements:

* Updated the frontend to display participants for each activity, including a list with delete buttons for unregistering, and improved error/success messaging. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R59) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R139)
* Added new CSS styles for participant lists, delete buttons, and empty participant states to enhance UI clarity and accessibility.

Testing and documentation:

* Introduced a suite of backend tests covering signup, unregister, error cases, and API responses, with state reset between tests.
* Updated documentation in `README.md` to include the new unregister endpoint and instructions for running tests.### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
